### PR TITLE
addeds support for custom http headers in android and ios

### DIFF
--- a/InTheHand.Forms/InTheHand.Forms.Platform.Android/MediaElementRenderer.cs
+++ b/InTheHand.Forms/InTheHand.Forms.Platform.Android/MediaElementRenderer.cs
@@ -196,6 +196,12 @@ namespace InTheHand.Forms.Platform.Android
             base.OnElementPropertyChanged(sender, e);
         }
 
+        protected override void OnSizeChanged(int w, int h, int oldw, int oldh)
+        {
+            base.OnSizeChanged(w, h, oldw, oldh);
+            UpdateLayoutParameters();
+        }
+
         private void UpdateLayoutParameters()
         {
             float ratio = (float)Element.NaturalVideoWidth / Element.NaturalVideoHeight;

--- a/InTheHand.Forms/InTheHand.Forms.Platform.Android/MediaElementRenderer.cs
+++ b/InTheHand.Forms/InTheHand.Forms.Platform.Android/MediaElementRenderer.cs
@@ -72,7 +72,7 @@ namespace InTheHand.Forms.Platform.Android
         {
             base.OnElementChanged(e);
 
-            if(e.OldElement != null)
+            if (e.OldElement != null)
             {
                 e.OldElement.SetRenderer(null);
 
@@ -83,7 +83,7 @@ namespace InTheHand.Forms.Platform.Android
                     _view.Dispose();
                 }
 
-                if(_controller != null)
+                if (_controller != null)
                 {
                     _controller.Dispose();
                     _controller = null;
@@ -127,7 +127,7 @@ namespace InTheHand.Forms.Platform.Android
                 }
                 else if (Element.Source.Scheme == "ms-appdata")
                 {
-                    _view.SetVideoPath(System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),Element.Source.LocalPath.Substring(1)));
+                    _view.SetVideoPath(System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), Element.Source.LocalPath.Substring(1)));
                 }
                 else
                 {
@@ -137,11 +137,11 @@ namespace InTheHand.Forms.Platform.Android
                     }
                     else
                     {
-                        _view.SetVideoURI(global::Android.Net.Uri.Parse(Element.Source.ToString()));
+                        _view.SetVideoURI(global::Android.Net.Uri.Parse(Element.Source.ToString()), Element.HttpHeaders);
                     }
                 }
 
-                if(Element.AutoPlay)
+                if (Element.AutoPlay)
                 {
                     _view.Start();
                 }
@@ -153,10 +153,10 @@ namespace InTheHand.Forms.Platform.Android
         {
             Element?.RaiseMediaOpened();
         }
-        
+
         protected override void OnElementPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
-            switch(e.PropertyName)
+            switch (e.PropertyName)
             {
                 case "AreTransportControlsEnabled":
                     _controller.Visibility = Element.AreTransportControlsEnabled ? ViewStates.Visible : ViewStates.Gone;
@@ -167,7 +167,7 @@ namespace InTheHand.Forms.Platform.Android
                     break;
 
                 case "CurrentState":
-                    switch(Element.CurrentState)
+                    switch (Element.CurrentState)
                     {
                         case MediaElementState.Playing:
                             _view.Start();

--- a/InTheHand.Forms/InTheHand.Forms.Platform.Android/VideoView.cs
+++ b/InTheHand.Forms/InTheHand.Forms.Platform.Android/VideoView.cs
@@ -26,7 +26,6 @@ namespace InTheHand.Forms.Platform.Android
             MediaMetadataRetriever retriever = new MediaMetadataRetriever();
             retriever.SetDataSource(path);
             ExtractMetadata(retriever);
-
             base.SetVideoPath(path);
         }
 
@@ -34,7 +33,7 @@ namespace InTheHand.Forms.Platform.Android
         {
             _duration = TimeSpan.Zero;
             _videoWidth = int.Parse(retriever.ExtractMetadata(MetadataKey.VideoWidth));
-            _videoHeight = int.Parse(retriever.ExtractMetadata(MetadataKey.VideoWidth));
+            _videoHeight = int.Parse(retriever.ExtractMetadata(MetadataKey.VideoHeight));
 
             string durationString = retriever.ExtractMetadata(MetadataKey.Duration);
             if (!string.IsNullOrEmpty(durationString))
@@ -44,12 +43,24 @@ namespace InTheHand.Forms.Platform.Android
             }
         }
 
+        public override void SetVideoURI(global::Android.Net.Uri uri, IDictionary<string, string> headers)
+        {
+            GetMetaData(uri, headers);
+            base.SetVideoURI(uri, headers);
+        }
+
         public override void SetVideoURI(global::Android.Net.Uri uri)
+        {
+            GetMetaData(uri, new Dictionary<string, string>());
+            base.SetVideoURI(uri);
+        }
+
+        private void GetMetaData(global::Android.Net.Uri uri, IDictionary<string, string> headers)
         {
             MediaMetadataRetriever retriever = new MediaMetadataRetriever();
             if (uri.Scheme.StartsWith("http"))
             {
-                retriever.SetDataSource(uri.ToString(), new Dictionary<string, string>());
+                retriever.SetDataSource(uri.ToString(), headers);
             }
             else
             {
@@ -57,8 +68,6 @@ namespace InTheHand.Forms.Platform.Android
             }
 
             ExtractMetadata(retriever);
-
-            base.SetVideoURI(uri);
         }
 
         public int VideoHeight
@@ -84,6 +93,6 @@ namespace InTheHand.Forms.Platform.Android
                 return _duration;
             }
         }
-        
+
     }
 }

--- a/InTheHand.Forms/InTheHand.Forms.Platform.iOS/MediaElementRenderer.cs
+++ b/InTheHand.Forms/InTheHand.Forms.Platform.iOS/MediaElementRenderer.cs
@@ -4,6 +4,7 @@ using CoreMedia;
 using Foundation;
 using InTheHand.Forms;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using UIKit;
 using Xamarin.Forms;
@@ -106,6 +107,25 @@ namespace InTheHand.Forms.Platform.iOS
             }
         }
 
+        private AVUrlAssetOptions GetOptionsWithHeaders(IDictionary<string, string> headers)
+        {
+            var nativeHeaders = new NSMutableDictionary();
+
+            foreach (var header in headers)
+            {
+                nativeHeaders.Add((NSString)header.Key, (NSString)header.Value);
+            }
+
+            var nativeHeadersKey = (NSString)"AVURLAssetHTTPHeaderFieldsKey";
+
+            var options = new AVUrlAssetOptions(NSDictionary.FromObjectAndKey(
+                nativeHeaders,
+                nativeHeadersKey
+            ));
+
+            return options;
+        }
+
         private void UpdateSource()
         {
             if (Element.Source != null)
@@ -122,7 +142,7 @@ namespace InTheHand.Forms.Platform.iOS
                 }
                 else
                 {
-                    asset = AVAsset.FromUrl(NSUrl.FromString(Element.Source.ToString()));
+                    asset = AVUrlAsset.Create(NSUrl.FromString(Element.Source.ToString()), GetOptionsWithHeaders(Element.HttpHeaders));
                 }
 
                 AVPlayerItem item = new AVPlayerItem(asset);
@@ -317,7 +337,7 @@ namespace InTheHand.Forms.Platform.iOS
 
         private static AVLayerVideoGravity StretchToGravity(Stretch stretch)
         {
-            switch(stretch)
+            switch (stretch)
             {
                 case Stretch.Fill:
                     return AVLayerVideoGravity.Resize;

--- a/InTheHand.Forms/MediaElement.cs
+++ b/InTheHand.Forms/MediaElement.cs
@@ -5,6 +5,7 @@
 // --------------------------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using Xamarin.Forms;
 
 namespace InTheHand.Forms
@@ -14,13 +15,12 @@ namespace InTheHand.Forms
     /// </summary>
     public sealed class MediaElement : View
     {
-        
         /// <summary>
         /// Identifies the AreTransportControlsEnabled dependency property.
         /// </summary>
         public static readonly BindableProperty AreTransportControlsEnabledProperty =
           BindableProperty.Create(nameof(AreTransportControlsEnabled), typeof(bool), typeof(MediaElement), false);
-        
+
         /// <summary>
         /// Identifies the AutoPlay dependency property.
         /// </summary>
@@ -61,7 +61,7 @@ namespace InTheHand.Forms
         /// Identifies the Position dependency property.
         /// </summary>
         public static readonly BindableProperty PositionProperty =
-          BindableProperty.Create(nameof(Position), typeof(TimeSpan), typeof(MediaElement), TimeSpan.Zero, validateValue:ValidatePosition);
+          BindableProperty.Create(nameof(Position), typeof(TimeSpan), typeof(MediaElement), TimeSpan.Zero, validateValue: ValidatePosition);
 
         private static bool ValidatePosition(BindableObject bindable, object value)
         {
@@ -147,7 +147,7 @@ namespace InTheHand.Forms
         {
             get
             {
-                if(_renderer != null)
+                if (_renderer != null)
                 {
                     return _renderer.NaturalVideoHeight;
                 }
@@ -179,6 +179,15 @@ namespace InTheHand.Forms
             set { SetValue(SourceProperty, value); }
         }
 
+        private IDictionary<string, string> _httpHeaders = new Dictionary<string, string>();
+        public IDictionary<string, string> HttpHeaders
+        {
+            get
+            {
+                return _httpHeaders;
+            }
+        }
+
         /// <summary>
         /// Gets the status of this MediaElement.
         /// </summary>
@@ -187,7 +196,7 @@ namespace InTheHand.Forms
             get { return (MediaElementState)GetValue(CurrentStateProperty); }
             internal set
             {
-                SetValue(CurrentStateProperty, value);                
+                SetValue(CurrentStateProperty, value);
             }
         }
 
@@ -203,11 +212,11 @@ namespace InTheHand.Forms
         {
             get
             {
-               if (_renderer != null)
+                if (_renderer != null)
                 {
                     return _renderer.Position;
                 }
-                
+
                 return (TimeSpan)GetValue(PositionProperty);
             }
 
@@ -230,7 +239,7 @@ namespace InTheHand.Forms
         /// </summary>
         public void Pause()
         {
-            if(CurrentState == MediaElementState.Playing)
+            if (CurrentState == MediaElementState.Playing)
             {
                 CurrentState = MediaElementState.Paused;
             }
@@ -297,7 +306,7 @@ namespace InTheHand.Forms
 
         internal void OnMediaEnded()
         {
-            if(MediaEnded != null)
+            if (MediaEnded != null)
             {
                 System.Diagnostics.Debug.WriteLine("Media Ended");
                 MediaEnded(this, EventArgs.Empty);


### PR DESCRIPTION
I've added support for custom headers in Android and IOS. I was unable to add custom headers for UWP since I don't have the UWP capabilities installed for visual studio, so I cannot even open the projects.

We need custom headers in our project to be able to get video's from an URL in our API. We need to authenticate with the API to be able to fetch the video.