### PR TITLE
Fixed nullreference when using file:// uri's

### DIFF
--- a/InTheHand.Forms/InTheHand.Forms.Platform.Android/VideoView.cs
+++ b/InTheHand.Forms/InTheHand.Forms.Platform.Android/VideoView.cs
@@ -58,7 +58,7 @@ namespace InTheHand.Forms.Platform.Android
         private void GetMetaData(global::Android.Net.Uri uri, IDictionary<string, string> headers)
         {
             MediaMetadataRetriever retriever = new MediaMetadataRetriever();
-            if (uri.Scheme.StartsWith("http"))
+            if (uri.Scheme != null && uri.Scheme.StartsWith("http"))
             {
                 retriever.SetDataSource(uri.ToString(), headers);
             }


### PR DESCRIPTION
Android renderen threw an error when using file:// uri's, because the scheme would be null.