### PR TITLE
MediaElementRenderer.cs -> Remove If IsPlaying

### DIFF
--- a/InTheHand.Forms/InTheHand.Forms.Platform.Android/MediaElementRenderer.cs
+++ b/InTheHand.Forms/InTheHand.Forms.Platform.Android/MediaElementRenderer.cs
@@ -60,12 +60,7 @@ namespace InTheHand.Forms.Platform.Android
         {
             get
             {
-                if (_view.IsPlaying)
-                {
-                    return TimeSpan.FromMilliseconds(_view.CurrentPosition);
-                }
-
-                return TimeSpan.Zero;
+                return TimeSpan.FromMilliseconds(_view.CurrentPosition);
             }
         }
 


### PR DESCRIPTION
Hi, I think it would be better to remove the if IsPlaying condition in order to be able to get the position even when the media is paused. Or maybe do something like if IsPaused or IsPlaying. Right now, when the media is paused we get 0 no matter where we are in the media because of the if.